### PR TITLE
Update for version 0.110

### DIFF
--- a/floureon/climate.py
+++ b/floureon/climate.py
@@ -24,7 +24,7 @@ from custom_components.floureon import (
     BROADLINK_TEMP_MANUAL
 )
 
-from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.components.climate import ClimateEntity, PLATFORM_SCHEMA
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.components.climate.const import (
@@ -68,7 +68,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([FloureonClimate(config)])
 
 
-class FloureonClimate(ClimateDevice, RestoreEntity):
+class FloureonClimate(ClimateEntity, RestoreEntity):
 
     def __init__(self, config):
         self._thermostat = BroadlinkThermostat(config.get(CONF_HOST), config.get(CONF_MAC))


### PR DESCRIPTION
Check Home Assistant configuration addon shows:
WARNING:homeassistant.components.climate:ClimateDevice is deprecated, modify FloureonClimate to extend ClimateEntity

So I changed some rows.